### PR TITLE
both NOR and OR used the same encoding

### DIFF
--- a/circuit.py
+++ b/circuit.py
@@ -38,7 +38,7 @@ class gfun(IntEnum):
     NAND = 2
     AND = 3
     NOR = 4
-    OR = 4
+    OR = 5
     XOR = 6
     XNOR = 7
     BUF = 8


### PR DESCRIPTION
I'm not sure if this is a typo or it's intentional for learning purposes that OR and NOR are encoded similarly. probably a typo. 